### PR TITLE
bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+/target/
+.classpath
+.project
+/.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>ncats-common-cli</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.2</version>
+  <version>0.9.3-SNAPSHOT</version>
   <name>ncats-common-cli</name>
 
   <url>https://github.com/ncats/ncats-common-cli</url>
@@ -71,13 +71,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>gov.nih.ncats</groupId>
       <artifactId>ncats-common</artifactId>
-      <version>0.3.3</version>
+      <version>0.3.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/gov/nih/ncats/common/cli/AtLeastOneOfOption.java
+++ b/src/main/java/gov/nih/ncats/common/cli/AtLeastOneOfOption.java
@@ -1,0 +1,165 @@
+package gov.nih.ncats.common.cli;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+
+class AtLeastOneOfOption implements InternalCliOptionBuilder{
+	private final InternalCliOptionBuilder[] choices;
+
+    private boolean isRequired;
+    private final List<CliValidator> validators = new ArrayList<>();
+    
+
+	AtLeastOneOfOption(CliOptionBuilder[] choices) {
+
+        if(choices ==null || choices.length<2){
+            throw new IllegalStateException("At Least One Of option requires at least 2 choices");
+        }
+        this.choices = new InternalCliOptionBuilder[choices.length];
+        for(int i=0; i< choices.length; i++){
+            this.choices[i] = (InternalCliOptionBuilder)choices[i];
+        }
+	}
+
+	@Override
+	public CliOptionBuilder addValidation(Predicate<Cli> validationRule, String errorMessage) {
+		 validators.add(new CliValidator(validationRule, errorMessage));
+	     return this;
+	}
+
+	@Override
+	public CliOptionBuilder addValidation(Predicate<Cli> validationRule, Function<Cli, String> errorMessageFunction) {
+		 validators.add(new CliValidator(validationRule, errorMessageFunction));
+	     return this;
+	}
+
+	@Override
+	public InternalCliOptionBuilder setRequired(boolean isRequired) {
+		this.isRequired = isRequired;
+		return this;
+	}
+
+	 @Override
+	    public InternalCliOption build() {
+	        return new AtLeastOneOfInternalCliOption(isRequired,
+	                Arrays.stream(choices).map(InternalCliOptionBuilder::build).toArray(i-> new InternalCliOption[i]),
+	                validators);
+	    }
+
+	    @Override
+	    public InternalCliOption build(boolean isRequired) {
+	        return new AtLeastOneOfInternalCliOption(isRequired,
+	                Arrays.stream(choices).map(InternalCliOptionBuilder::build).toArray(i-> new InternalCliOption[i]),
+	                validators);
+
+	    }
+	
+	private static class AtLeastOneOfInternalCliOption implements InternalCliOption{
+
+        private final InternalCliOption[] choices;
+        private final boolean isRequired;
+
+        private final List<CliValidator> validators;
+
+        public AtLeastOneOfInternalCliOption(boolean isRequired, InternalCliOption[] choices,
+                                      List<CliValidator> validators) {
+            this.choices = choices;
+            this.isRequired = isRequired;
+            this.validators = validators;
+
+        }
+
+        @Override
+        public void addValidator(CliValidator validator) {
+            validators.add(validator);
+        }
+        @Override
+        public Optional<String> generateUsage(boolean force) {
+            if(!force && !isRequired){
+                return Optional.empty();
+            }
+            List<String> list = new ArrayList<>(choices.length);
+            for(InternalCliOption choice : choices){
+               choice.generateUsage(true).ifPresent(list::add);
+            }
+            if(list.isEmpty()){
+                return Optional.empty();
+            }
+            return Optional.of(list.stream().collect(Collectors.joining(" | ", "[", "]")));
+        }
+
+        @Override
+        public void addTo(InternalCliSpecification spec, Boolean forceIsRequired) {
+            for(InternalCliOption choice : choices){
+                choice.addTo(spec, false);
+            }
+        }
+
+        @Override
+        public Optional<String> getMissing(Cli cli) {
+            if(isPresent(cli)){
+                return Optional.empty();
+            }
+            List<String> missing = new ArrayList<>();
+            for(InternalCliOption choice : choices){
+                choice.getMissing(cli).ifPresent(missing::add);
+            }
+            return Optional.ofNullable(missing.stream().collect(Collectors.joining(" | ", "[ ", " ]")));
+        }
+
+        @Override
+        public boolean isRequired() {
+            return isRequired;
+        }
+
+        @Override
+        public boolean isPresent(Cli cli) {
+            for(InternalCliOption choice : choices){
+                if(choice.isPresent(cli)){
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void validate(Cli cli) throws CliValidationException {
+            List<String> seen = getSeenList(cli);
+           
+            if(isRequired && seen.size() ==0){
+                throw new CliValidationException("AtLeastOneOf option was required but did not find selected option choice");
+            }
+            for(InternalCliOption choice : choices){
+                choice.validate(cli);
+            }
+            for(CliValidator v : validators){
+                v.validate(cli);
+            }
+        }
+        @Override
+        public List<String> getSeenList(Cli cli) {
+            List<String> list = new ArrayList<>();
+            for(InternalCliOption choice : choices){
+                List<String> seen =choice.getSeenList(cli);
+
+                if(!seen.isEmpty()){
+                    list.add(seen.stream().collect(Collectors.joining(",", "(",")")));
+                }
+            }
+            return list;
+        }
+        @Override
+        public void fireConsumerIfNeeded(Cli cli) throws CliValidationException {
+            for(InternalCliOption choice : choices){
+                choice.fireConsumerIfNeeded(cli);
+            }
+        }
+    }
+
+}

--- a/src/main/java/gov/nih/ncats/common/cli/Cli.java
+++ b/src/main/java/gov/nih/ncats/common/cli/Cli.java
@@ -27,8 +27,10 @@ public class Cli {
 
     private final org.apache.commons.cli.CommandLine delegate;
 
-    Cli(org.apache.commons.cli.CommandLine cmd){
+    private String[] trailers;
+    Cli(org.apache.commons.cli.CommandLine cmd, String[] trailers){
         this.delegate = cmd;
+        this.trailers = trailers;
     }
 
     /**
@@ -47,5 +49,21 @@ public class Cli {
 
     public boolean helpRequested(){
         return delegate.hasOption("h") || delegate.hasOption("help");
+    }
+    /**
+     * Get the ith trailer.
+     * @param i the index into the array of trailers on the command line.
+     * @return the trailer value as a String.
+     * 
+     * @throws IndexOutOfBoundsException if i is less than zero or more than number of trailers.
+     * 
+     * @see #getNumberOfTrailers()
+     */
+    public String getTrailer(int i) {
+    	return trailers[i];
+    }
+    
+    public int getNumberOfTrailers() {
+    	return trailers.length;
     }
 }

--- a/src/main/java/gov/nih/ncats/common/cli/CliSpecification.java
+++ b/src/main/java/gov/nih/ncats/common/cli/CliSpecification.java
@@ -392,13 +392,13 @@ public class CliSpecification {
 
 
         while(true){
-            text = padding+ text.substring(pos).trim();
+            text = text.substring(pos).trim();
             pos = findWrapPos(text, width, nextLineTabStop);
             if(pos == -1){
-                builder.append(text);
+                builder.append(padding).append(text);
                 return;
             }
-            builder.append(rTrim(text.substring(0, pos))).append(NEW_LINE);
+            builder.append(padding).append(rTrim(text.substring(0, pos))).append(NEW_LINE);
         }
     }
 

--- a/src/main/java/gov/nih/ncats/common/cli/CliSpecification.java
+++ b/src/main/java/gov/nih/ncats/common/cli/CliSpecification.java
@@ -114,6 +114,20 @@ public class CliSpecification {
     public static CliOptionBuilder group(CliOptionBuilder... options){
         return new GroupedOption(options);
     }
+    /**
+     * Create a new group of options where the specification
+     * is only valid if at least one of the given options
+     * is selected. Nesting other groups as one of the "at least one of" options is allowed.
+     * By default this group is not required,
+     * to make it required in the specification set the {@link CliOptionBuilder#setRequired(boolean)}
+     * method.
+     * @param radioOptions a varargs list of radio options;
+     *                     none of the options may be null.
+     * @return a new {@link CliOptionBuilder}.
+     */
+    public static CliOptionBuilder atLeastOneOf(CliOptionBuilder... options){
+        return new AtLeastOneOfOption(options);
+    }
     private final Options options;
     private   InternalCliOption internalCliOption;
 

--- a/src/main/java/gov/nih/ncats/common/cli/Trailer.java
+++ b/src/main/java/gov/nih/ncats/common/cli/Trailer.java
@@ -1,0 +1,31 @@
+package gov.nih.ncats.common.cli;
+
+import gov.nih.ncats.common.functions.ThrowableConsumer;
+
+public class Trailer {
+
+	private final String name;
+	private final String description;
+	
+	private final ThrowableConsumer<String, CliValidationException> consumer;
+	
+	Trailer(String name, String description, ThrowableConsumer<String, CliValidationException> consumer) {
+		this.name = name;
+		this.description = description;
+		this.consumer = consumer;
+	}
+
+	public void fireConsumerIfNeeded(String arg) throws CliValidationException {
+        consumer.accept(arg);
+        
+    }
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+	
+}

--- a/src/main/java/gov/nih/ncats/common/cli/TrailerBuilder.java
+++ b/src/main/java/gov/nih/ncats/common/cli/TrailerBuilder.java
@@ -1,0 +1,127 @@
+package gov.nih.ncats.common.cli;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+
+import gov.nih.ncats.common.functions.ThrowableConsumer;
+import gov.nih.ncats.common.functions.ThrowableFunction;
+import gov.nih.ncats.common.functions.ThrowableIntConsumer;
+
+public class TrailerBuilder {
+
+	private String name;
+	private String description;
+	
+	private ThrowableConsumer<String, CliValidationException> consumer = (s) ->{}; //no -op
+	
+	public Trailer build() {
+		return new Trailer(this.name, this.description, this.consumer);
+		
+	}
+	    public <T extends Throwable> TrailerBuilder setter(ThrowableConsumer<String, T> consumer){
+	        return setter(ThrowableFunction.identity(), consumer,null);
+	    }
+
+	    public <T extends Throwable> TrailerBuilder setToFile(ThrowableConsumer<File, T> consumer) {
+	        Objects.requireNonNull(consumer);
+	        this.consumer = s -> {
+	            try{
+	                consumer.accept(new File(s));
+	            }catch(Throwable t){
+	                if( t instanceof CliValidationException){
+	                    throw (CliValidationException)t;
+	                }
+	                throw new CliValidationException(t.getMessage(), t);
+	            }
+	        };
+	        return this;
+	    }
+
+	    public <T extends Throwable> TrailerBuilder setToInt(ThrowableIntConsumer<T> consumer, IntPredicate validator) {
+	        if(validator == null){
+	            return setToInt(consumer);
+	        }
+
+	        this.consumer = s->{
+	            int value;
+	            try {
+	                value = Integer.parseInt(s);
+	            }catch(Throwable t){
+	                throw new CliValidationException("error parsing int value", t);
+	            }
+	            if(validator.test(value)){
+	                try {
+	                    consumer.accept(value);
+	                }catch(Throwable t){
+	                    if( t instanceof CliValidationException){
+	                        throw (CliValidationException)t;
+	                    }
+	                    throw new CliValidationException(t.getMessage(), t);
+	                }
+	            }else{
+	                throw new CliValidationException("setter did not pass validation test");
+	            }
+	        };
+	        return this;
+	    }
+
+	    public <T extends Throwable, R> TrailerBuilder setter(ThrowableFunction<String, R, T> typeConverter,
+	                                                          ThrowableConsumer<R, T> consumer, Predicate<R> validator){
+	        if(validator ==null){
+	            this.consumer=s-> {
+	                try {
+	                    consumer.accept(typeConverter.apply(s));
+	                } catch (Throwable t) {
+	                    if( t instanceof CliValidationException){
+	                        throw (CliValidationException)t;
+	                    }
+	                    throw new CliValidationException(t.getMessage(), t);
+	                }
+	            };
+	        }else{
+
+	            this.consumer = s->{
+	                R value;
+	                try {
+	                    value = typeConverter.apply(s);
+	                } catch (Throwable t) {
+	                    if( t instanceof CliValidationException){
+	                        throw (CliValidationException)t;
+	                    }
+	                   throw new CliValidationException(t);
+	                }
+	                if(validator.test(value)){
+	                    try {
+	                        consumer.accept(value);
+	                    }catch(Throwable t){
+	                        if( t instanceof CliValidationException){
+	                            throw (CliValidationException)t;
+	                        }
+	                        throw new CliValidationException(t.getMessage(), t);
+	                    }
+	                }else{
+	                    throw new CliValidationException("setter did not pass validation test");
+	                }
+	            };
+	        }
+	        return this;
+	    }
+
+	    public <T extends Throwable> TrailerBuilder setter(ThrowableConsumer<String, T> consumer, Predicate<String> validator){
+	        return setter(ThrowableFunction.identity(), consumer, validator);
+	    }
+	    
+	    public <T extends Throwable> TrailerBuilder setToInt(ThrowableIntConsumer<T> consumer){
+	        Objects.requireNonNull(consumer);
+	        this.consumer = s ->{
+	            try {
+	                consumer.accept(Integer.parseInt(s));
+	            }catch(Throwable t){
+	                throw new CliValidationException(t);
+	            }
+	        };
+	        return this;
+	    }
+}

--- a/src/test/java/gov/nih/ncats/common/cli/TestCommandLine.java
+++ b/src/test/java/gov/nih/ncats/common/cli/TestCommandLine.java
@@ -24,6 +24,11 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -68,8 +73,45 @@ public class TestCommandLine {
 
                 .parse(toArgList("-path /usr/local/foo/bar/baz.txt"));
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
+    /**
+     * Helper method that is not OS dependent.
+     * @param expectedPath
+     * @param actualFile
+     */
+    private static void assertPathMatches(String expectedPath, File actualFile) {
+    	
+    	if("/".equals(File.separator)) {
+    		assertEquals(new File(expectedPath).getAbsolutePath(), actualFile.getAbsolutePath());
+    	}else {
+    		String p = actualFile.getPath();
+    		String fixed = p.replace(File.separator, "/");
+
+        	
+        	assertEquals(expectedPath, fixed);
+    	}
+    }
+    /**
+     * Helper method that is not OS dependent.
+     * @param expectedPath
+     * @param actualFile
+     */
+    private static void assertPathMatches(String expectedPath, String actualPath) {
+    	
+    	if("/".equals(File.separator)) {
+    		assertEquals(new File(expectedPath).getAbsolutePath(), actualPath);
+    	}else {
+    		String[] parts = FILE_SEP_PATTERN.split(expectedPath);
+    		
+        	Path expected = Path.of(parts[0], Arrays.copyOfRange(parts, 1, parts.length-1)).toAbsolutePath();
+        	
+        	String[] actualParts = FILE_SEP_PATTERN.split(actualPath);
+        	Path actual = Path.of(actualParts[0], Arrays.copyOfRange(actualParts, 1, actualParts.length -1));
+        	assertEquals(expected, actual.toAbsolutePath());
+    	}
+    }
+    private static final Pattern FILE_SEP_PATTERN = Pattern.compile("\\/");
 
     @Test
     public void multipleOptions() throws IOException{
@@ -82,7 +124,7 @@ public class TestCommandLine {
 
                 .parse(toArgList("-path /usr/local/foo/bar/baz.txt"));
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
 
         assertTrue(cli.hasOption("path"));
         assertEquals("/usr/local/foo/bar/baz.txt", cli.getOptionValue("path"));
@@ -97,7 +139,7 @@ public class TestCommandLine {
                                 option("a").setToInt(ex::setA))
                 .parse(new URL("http://example.com?path=/usr/local/foo/bar/baz.txt&a=2"));
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
         assertEquals(2, ex.getA());
 
     }
@@ -141,7 +183,7 @@ public class TestCommandLine {
 
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt"});
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test
@@ -157,7 +199,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test
@@ -172,7 +214,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123", "-bar", "lah"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test(expected = CliValidationException.class)
@@ -204,7 +246,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123", "-bar", "stool"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test
@@ -223,7 +265,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123", "-bar", "stool"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test
@@ -243,7 +285,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123", "-bar", "stool"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
     @Test(expected = CliValidationException.class)
@@ -280,7 +322,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
     @Test(expected = CliValidationException.class)
     public void nestedGroupsRequiredRadioGroupInsideGenericGroupNotSelected() throws IOException{
@@ -299,7 +341,7 @@ public class TestCommandLine {
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-foo", "123"});
 
         assertEquals(123, ex.getA());
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
 
@@ -312,7 +354,7 @@ public class TestCommandLine {
 
                 .parse(new String[]{"-foo", "x", "-path","/usr/local/foo/bar/baz.txt"});
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
 
@@ -342,7 +384,7 @@ public class TestCommandLine {
 
                 .parse(new String[]{"-path","/usr/local/foo/bar/baz.txt", "-bar", "stool"});
 
-        assertEquals("/usr/local/foo/bar/baz.txt", ex.getMyFile().getAbsolutePath());
+        assertPathMatches("/usr/local/foo/bar/baz.txt", ex.getMyFile());
     }
 
 


### PR DESCRIPTION
A couple of improvements :
1. "at least one" of grouping to say at least one of these options is required, previously there wasn't a clean way of saying that.
2. bug fix for printing usage text that required more than 2 lines of text per element.  Before the fix code would infinite loop.
3. added support for adding "trailers" to end of the command which are usually file paths without a parameter. 